### PR TITLE
Fix incorrect percentage calculation in Sessions by Punctuality

### DIFF
--- a/components/common/dashboard-cards.tsx
+++ b/components/common/dashboard-cards.tsx
@@ -155,7 +155,7 @@ export function SessionsByPunctuality({
   return (
     <PieChartCard
       chartData={chartData}
-      totalSessions={10}
+      totalSessions={totalSessions}
       title="Sessions by punctuality"
       popoverContent="'On time' are sessions where you joined within 1 minute after the scheduled start time"
       categories={["On time", "Late"]}


### PR DESCRIPTION
The totalSessions prop was hardcoded to 10 instead of using the actual value passed from the parent component. This caused the percentage calculation to be wrong (dividing by 10 instead of actual total).

Fixes #38