### PR TITLE
Show precise total time and time-per-duration breakdown

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -5,11 +5,12 @@ import pandas as pd
 from pydantic import BaseModel, Field, model_validator
 from api_utils.metric import calc_max_daily_streak, \
     calc_curr_streak, calc_repeat_partners, calc_daily_record, calc_cumulative_sessions_chart, calc_duration_pie_data, \
-    calc_punctuality_pie_data, calc_chart_data_by_hour, calc_heatmap_data, calc_history_data, calc_chart_data_by_range
+    calc_punctuality_pie_data, calc_chart_data_by_hour, calc_heatmap_data, \
+    calc_time_heatmap_data, calc_history_data, calc_chart_data_by_range
 from api_utils.supabase import get_weekly_goal, update_daily_streak, \
     update_weekly_goal
 from api_utils.time import format_date_label, get_curr_day_start, \
-    get_curr_month_start, get_curr_week_start, get_curr_year_start, ms_to_h, \
+    get_curr_month_start, get_curr_week_start, get_curr_year_start, \
     ms_to_h_decimal, ms_to_m, WeekStartDay
 from api_utils.request import get_session_id, get_access_token, SessionNotFound
 from api_utils.focusmate import get_data
@@ -111,6 +112,8 @@ async def get_streak(session_id: SessionIdDep,
         "max_daily_streak": calc_max_daily_streak(sessions),
         "heatmap_data": calc_heatmap_data(sessions, local_timezone,
                                           week_start=week_start),
+        "time_heatmap_data": calc_time_heatmap_data(sessions, local_timezone,
+                                                    week_start=week_start),
         "history_data": calc_history_data(
             all_sessions, local_timezone, head=3),
         "daily": {
@@ -275,14 +278,18 @@ async def get_month(session_id: SessionIdDep):
 
     date_format = "%B %Y"
 
+    curr_month_hours = ms_to_h_decimal(curr_month_sessions['duration'].sum())
+    prev_month_hours = ms_to_h_decimal(prev_month_sessions['duration'].sum())
+
     return {
         "curr_period": {
             "subheading": format_date_label(curr_month_start, date_format),
             "sessions_total": len(curr_month_sessions),
             "sessions_delta": len(curr_month_sessions) - len(prev_month_sessions),
-            "hours_total": ms_to_h(curr_month_sessions['duration'].sum()),
-            "hours_delta": ms_to_h(curr_month_sessions['duration'].sum() -
-                                   prev_month_sessions['duration'].sum()),
+            "hours_total": curr_month_hours,
+            # Delta comes off the rounded hours so it reconciles with the two
+            # numbers a user can actually see
+            "hours_delta": round(curr_month_hours - prev_month_hours, 1),
             "partners_total": curr_month_sessions['partner_id'].nunique(),
             "partners_repeat": calc_repeat_partners(curr_month_sessions),
             "period_type": "month",
@@ -329,21 +336,25 @@ async def get_year(session_id: SessionIdDep):
 
     date_format = "%Y"
 
+    curr_year_hours = ms_to_h_decimal(curr_year_sessions['duration'].sum())
+    prev_year_hours = ms_to_h_decimal(prev_year_sessions['duration'].sum())
+
     return {
         "curr_period": {
             "subheading": format_date_label(curr_year_start, date_format),
             "sessions_total": len(curr_year_sessions),
             "sessions_delta": len(curr_year_sessions) - len(prev_year_sessions),
-            "hours_total": ms_to_h(curr_year_sessions['duration'].sum()),
-            "hours_delta": ms_to_h(curr_year_sessions['duration'].sum() -
-                                   prev_year_sessions['duration'].sum()),
+            "hours_total": curr_year_hours,
+            # Delta comes off the rounded hours so it reconciles with the two
+            # numbers a user can actually see
+            "hours_delta": round(curr_year_hours - prev_year_hours, 1),
             "partners_total": curr_year_sessions['partner_id'].nunique(),
             "partners_repeat": calc_repeat_partners(curr_year_sessions),
             "period_type": "year",
         },
         "prev_period": {
             "sessions_total": len(prev_year_sessions),
-            "hours_total": ms_to_h(prev_year_sessions['duration'].sum()),
+            "hours_total": prev_year_hours,
             "partners_total": prev_year_sessions['partner_id'].nunique(),
             "partners_repeat": calc_repeat_partners(prev_year_sessions),
             "subheading": format_date_label(prev_year_start, date_format),
@@ -379,7 +390,7 @@ async def get_lifetime(session_id: SessionIdDep):
         "curr_period": {
             "subheading": f"{first_session_date} - Present",
             "sessions_total": profile.get("totalSessionCount"),
-            "hours_total": ms_to_h(sessions['duration'].sum()),
+            "hours_total": ms_to_h_decimal(sessions['duration'].sum()),
             "partners_total": sessions['partner_id'].nunique(),
             "partners_repeat": calc_repeat_partners(sessions),
             "first_session_date": first_session_date,

--- a/api_utils/metric.py
+++ b/api_utils/metric.py
@@ -2,7 +2,7 @@ import pandas as pd
 from typing import Any, Dict, List, Literal
 import numpy as np
 from api_utils.time import get_naive_local_today, m_to_ms, \
-    ms_to_h, WeekStartDay
+    ms_to_h_decimal, WeekStartDay
 
 # How late you can join and still count as on time. One definition shared by
 # the history table and the punctuality chart -- they used to disagree (2
@@ -158,6 +158,41 @@ def calc_max_daily_streak(sessions: pd.DataFrame,
     }
 
 
+def _one_year_calendar_window(local_timezone: str,
+                              week_start: WeekStartDay) -> tuple:
+    '''
+    The Nivo TimeRange calendar's one-year window: from the start of the week
+    containing "one year ago" through tomorrow (Nivo's "to" is exclusive).
+    Shared by calc_heatmap_data and calc_time_heatmap_data so the two
+    calendars always cover the same days.
+
+    Returns
+    -------
+    tuple
+        (window_start, tomorrow), both tz-naive local timestamps.
+    '''
+    # start_time is naive local, so the window has to be anchored to the user's
+    # day. pd.Timestamp.today() is the server's clock -- UTC on Vercel -- which
+    # both slides the window for anyone outside that timezone and, because it
+    # keeps the current time of day, clips sessions earlier on the first day
+    today = get_naive_local_today(local_timezone).normalize()
+
+    # Nivo TimeRange calendar component's 'to' date is exclusive, so we need to
+    # add one day to the current date
+    tomorrow = today + pd.DateOffset(days=1)
+
+    # Calculate the start of the week one year ago based on week_start preference
+    one_year_ago = tomorrow - pd.DateOffset(years=1)
+    if week_start == "sunday":
+        # Sunday = 6 in weekday(), shift so Sunday = 0
+        days_to_week_start = (one_year_ago.weekday() + 1) % 7
+    else:  # monday
+        days_to_week_start = one_year_ago.weekday()
+    window_start = one_year_ago - pd.DateOffset(days=days_to_week_start)
+
+    return window_start, tomorrow
+
+
 def calc_heatmap_data(sessions: pd.DataFrame,
                       local_timezone: str,
                       week_start: WeekStartDay = "monday") -> dict:
@@ -182,33 +217,13 @@ def calc_heatmap_data(sessions: pd.DataFrame,
         the Nivo TimeRange calendar component, as well as the total number of
         sessions in the past year.
     '''
-
-    # start_time is naive local, so the window has to be anchored to the user's
-    # day. pd.Timestamp.today() is the server's clock -- UTC on Vercel -- which
-    # both slides the window for anyone outside that timezone and, because it
-    # keeps the current time of day, clips sessions earlier on the first day
-    today = get_naive_local_today(local_timezone).normalize()
-
-    # Nivo TimeRange calendar component's 'to' date is exclusive, so we need to
-    # add one day to the current date
-    tomorrow = today + pd.DateOffset(days=1)
-    tomorrow_str = tomorrow.strftime('%Y-%m-%d')
-
-    # Calculate the start of the week one year ago based on week_start preference
-    one_year_ago = tomorrow - pd.DateOffset(years=1)
-    if week_start == "sunday":
-        # Sunday = 6 in weekday(), shift so Sunday = 0
-        days_to_week_start = (one_year_ago.weekday() + 1) % 7
-    else:  # monday
-        days_to_week_start = one_year_ago.weekday()
-    one_year_ago_week_start = one_year_ago - pd.DateOffset(
-        days=days_to_week_start)
-    one_year_ago_week_start_str = one_year_ago_week_start.strftime('%Y-%m-%d')
+    window_start, tomorrow = _one_year_calendar_window(
+        local_timezone, week_start)
 
     sessions = sessions.copy()
 
     sessions = sessions[
-        (sessions['start_time'] >= one_year_ago_week_start) &
+        (sessions['start_time'] >= window_start) &
         (sessions['start_time'] <= tomorrow)
     ]
 
@@ -223,10 +238,63 @@ def calc_heatmap_data(sessions: pd.DataFrame,
     past_year_sessions = len(sessions)
 
     return {
-        "from": one_year_ago_week_start_str,
-        "to": tomorrow_str,
+        "from": window_start.strftime('%Y-%m-%d'),
+        "to": tomorrow.strftime('%Y-%m-%d'),
         "data": heatmap_data,
         "past_year_sessions": past_year_sessions
+    }
+
+
+def calc_time_heatmap_data(sessions: pd.DataFrame,
+                           local_timezone: str,
+                           week_start: WeekStartDay = "monday") -> dict:
+    '''
+    Same as calc_heatmap_data, but each day's value is the total time spent in
+    sessions that day (in decimal hours) rather than a session count.
+
+    Parameters
+    ----------
+    sessions : pd.DataFrame
+        A DataFrame containing all completed sessions.
+    local_timezone : str
+        The user's IANA timezone, used to anchor the one-year window to their
+        calendar days.
+    week_start : WeekStartDay
+        Either "sunday" or "monday". Determines the first day of the week
+        for the heatmap display.
+
+    Returns
+    -------
+    dict
+        A dictionary containing data for the "from", "to", and "data" props of
+        the Nivo TimeRange calendar component, as well as the total hours
+        spent in sessions in the past year.
+    '''
+    window_start, tomorrow = _one_year_calendar_window(
+        local_timezone, week_start)
+
+    sessions = sessions.copy()
+
+    sessions = sessions[
+        (sessions['start_time'] >= window_start) &
+        (sessions['start_time'] <= tomorrow)
+    ]
+
+    sessions['start_date_str'] = \
+        sessions['start_time'].dt.strftime('%Y-%m-%d')
+    daily_duration = sessions.groupby('start_date_str')['duration'].sum()
+    heatmap_data = daily_duration.reset_index()
+    heatmap_data.columns = ['day', 'value']  # expected by Nivo calendar
+    heatmap_data['value'] = heatmap_data['value'].apply(ms_to_h_decimal)
+    heatmap_data = heatmap_data.to_dict(orient='records')
+
+    past_year_hours = ms_to_h_decimal(sessions['duration'].sum())
+
+    return {
+        "from": window_start.strftime('%Y-%m-%d'),
+        "to": tomorrow.strftime('%Y-%m-%d'),
+        "data": heatmap_data,
+        "past_year_hours": past_year_hours
     }
 
 
@@ -410,17 +478,15 @@ def calc_history_data(sessions: pd.DataFrame, local_timezone: str,
 def calc_duration_pie_data(sessions: pd.DataFrame):
     return [
         {
-            "duration": "25m",
-            "amount": len(sessions[sessions['duration'] == m_to_ms(25)])
-        },
-        {
-            "duration": "50m",
-            "amount": len(sessions[sessions['duration'] == m_to_ms(50)])
-        },
-        {
-            "duration": "75m",
-            "amount": len(sessions[sessions['duration'] == m_to_ms(75)])
+            "duration": label,
+            "amount": len(bucket),
+            "hours": ms_to_h_decimal(bucket['duration'].sum()),
         }
+        for label, bucket in (
+            ("25m", sessions[sessions['duration'] == m_to_ms(25)]),
+            ("50m", sessions[sessions['duration'] == m_to_ms(50)]),
+            ("75m", sessions[sessions['duration'] == m_to_ms(75)]),
+        )
     ]
 
 
@@ -512,5 +578,5 @@ def calc_daily_record(sessions: pd.DataFrame) -> Dict[str, Any]:
     daily_duration = sessions.groupby('start_date')['duration'].sum()
     return {
         'date': daily_duration.idxmax().strftime('%b %-d, %Y'),
-        'duration': ms_to_h(daily_duration.max())
+        'duration': ms_to_h_decimal(daily_duration.max())
     }

--- a/api_utils/time.py
+++ b/api_utils/time.py
@@ -106,10 +106,6 @@ def ms_to_m(ms: int):
     return int(round(ms / 60000))
 
 
-def ms_to_h(ms: int):
-    return int(round(ms / 3600000))
-
-
 def ms_to_h_decimal(ms: int):
     """Hours kept to one decimal place, for periods short enough that rounding
     to whole hours loses too much (e.g. three 25m sessions in a day)."""

--- a/app/dashboard/streak/components/time-heatmap.tsx
+++ b/app/dashboard/streak/components/time-heatmap.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { Heatmap } from "@/components/charts/heatmap"
+import { Card } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function TimeHeatmap({ data }: { data: any }) {
+  return (
+    <Card
+      title="Time heatmap"
+      subtitle={
+        data &&
+        `${data.time_heatmap_data.past_year_hours.toLocaleString()} hours in the last year`
+      }
+      className="sm:col-span-6"
+    >
+      {data ? (
+        <Heatmap
+          data={data.time_heatmap_data}
+          valueLabel={(value) => `${value}h`}
+        />
+      ) : (
+        <>
+          <Skeleton className="w-[180px] h-[18px]" />
+          <Skeleton className="mt-6 w-full h-[138px]" />
+        </>
+      )}
+    </Card>
+  )
+}

--- a/app/dashboard/streak/page.tsx
+++ b/app/dashboard/streak/page.tsx
@@ -14,6 +14,7 @@ import {
   WeeklyStreak,
 } from "@/app/dashboard/streak/components/w-m-streak"
 import { SessionsHeatmap } from "@/app/dashboard/streak/components/sessions-heatmap"
+import { TimeHeatmap } from "@/app/dashboard/streak/components/time-heatmap"
 import { RecentSessions } from "@/app/dashboard/streak/components/recent-sessions"
 import { fetchDashboardData } from "@/lib/dashboard-data"
 import { takeScreenshot } from "@/lib/screenshot"
@@ -60,6 +61,7 @@ export default function Streak() {
         <WeeklyStreak data={data} />
         <MonthlyStreak data={data} />
         <SessionsHeatmap data={data} />
+        <TimeHeatmap data={data} />
       </div>
 
       <div />

--- a/components/charts/heatmap.tsx
+++ b/components/charts/heatmap.tsx
@@ -29,13 +29,14 @@ function DaySvg({ color }: { color: string }) {
 
 export function Heatmap({
   data,
+  valueLabel = (value) => `${value} session${value !== 1 ? "s" : ""}`,
 }: {
   data: {
     data: CalendarData["data"]
     from: CalendarData["from"]
     to: CalendarData["to"]
-    past_year_sessions: number
   }
+  valueLabel?: (value: number) => string
 }) {
   const { isBelowSm } = useBreakpoint("sm")
   const { weekStart } = useWeekStart()
@@ -83,9 +84,7 @@ export function Heatmap({
                 <Divider className="my-2" />
                 <div className="flex px-4 items-center">
                   <DaySvg color={color} />
-                  <Text>
-                    {value} session{Number(value) !== 1 && "s"}
-                  </Text>
+                  <Text>{valueLabel(Number(value))}</Text>
                 </div>
               </div>
             )

--- a/components/common/dashboard-cards.tsx
+++ b/components/common/dashboard-cards.tsx
@@ -207,21 +207,23 @@ export function SessionsByDuration({ data }: { data: any }) {
       tableContent={
         <>
           {chartData &&
-            chartData.map((item: { duration: string; amount: number }) => {
-              return (
-                <Text
-                  key={item.duration}
-                  className="flex justify-between border-b border-stone-200 last:border-none py-2 last:pb-0"
-                >
-                  <span>{item.duration}</span>
-                  <span>
-                    {item.amount.toLocaleString()} (
-                    {toPercentage(item.amount, totalSessions)}
-                    %)
-                  </span>
-                </Text>
-              )
-            })}
+            chartData.map(
+              (item: { duration: string; amount: number; hours: number }) => {
+                return (
+                  <Text
+                    key={item.duration}
+                    className="flex justify-between border-b border-stone-200 last:border-none py-2 last:pb-0"
+                  >
+                    <span>{item.duration}</span>
+                    <span>
+                      {item.amount.toLocaleString()} (
+                      {toPercentage(item.amount, totalSessions)}
+                      %) &middot; {item.hours}h
+                    </span>
+                  </Text>
+                )
+              }
+            )}
         </>
       }
     />

--- a/lib/demo/metrics.ts
+++ b/lib/demo/metrics.ts
@@ -14,6 +14,7 @@ import {
   DURATION_KEYS,
   DurationKey,
   emptyCounts,
+  totalDurationMs,
 } from "./sessions"
 
 // Mirrors ON_TIME_GRACE_SECONDS in api_utils/metric.py. History and the
@@ -27,7 +28,7 @@ import {
   dayNumber,
   getCurrWeekStart,
   isoDate,
-  msToH,
+  msToHDecimal,
   pyRound,
   pyWeekday,
   startOfDay,
@@ -201,20 +202,27 @@ export function calcMaxDailyStreak(sessions: DemoSession[]): {
   }
 }
 
-export function calcHeatmapData(
-  sessions: DemoSession[],
-  now: Date,
-  weekStart: WeekStartDay = "monday"
-) {
-  // The Nivo calendar's "to" is exclusive, hence tomorrow rather than today.
-  // Anchored to midnight, matching calc_heatmap_data: carrying the time of day
-  // pushed the week-start day out of the window, leaving the first column
-  // empty, and dropped sessions earlier in the day than the current time.
+// The Nivo calendar's "to" is exclusive, hence tomorrow rather than today.
+// Anchored to midnight, matching _one_year_calendar_window: carrying the time
+// of day pushed the week-start day out of the window, leaving the first
+// column empty, and dropped sessions earlier in the day than the current
+// time. Shared by calcHeatmapData and calcTimeHeatmapData so both calendars
+// cover the same days.
+function oneYearCalendarWindow(now: Date, weekStart: WeekStartDay) {
   const tomorrow = addDays(startOfDay(now), 1)
   const oneYearAgo = addYears(tomorrow, -1)
   const daysToWeekStart =
     weekStart === "sunday" ? oneYearAgo.getDay() : pyWeekday(oneYearAgo)
   const windowStart = addDays(oneYearAgo, -daysToWeekStart)
+  return { windowStart, tomorrow }
+}
+
+export function calcHeatmapData(
+  sessions: DemoSession[],
+  now: Date,
+  weekStart: WeekStartDay = "monday"
+) {
+  const { windowStart, tomorrow } = oneYearCalendarWindow(now, weekStart)
 
   const inWindow = sessions.filter(
     (session) => session.start >= windowStart && session.start <= tomorrow
@@ -235,6 +243,37 @@ export function calcHeatmapData(
     to: isoDate(tomorrow),
     data,
     past_year_sessions: inWindow.length,
+  }
+}
+
+/** Same as calcHeatmapData, but each day's value is the total time spent in
+ * sessions that day (in decimal hours) rather than a session count. */
+export function calcTimeHeatmapData(
+  sessions: DemoSession[],
+  now: Date,
+  weekStart: WeekStartDay = "monday"
+) {
+  const { windowStart, tomorrow } = oneYearCalendarWindow(now, weekStart)
+
+  const inWindow = sessions.filter(
+    (session) => session.start >= windowStart && session.start <= tomorrow
+  )
+
+  const durations: Record<string, number> = {}
+  inWindow.forEach((session) => {
+    const day = isoDate(session.start)
+    durations[day] = (durations[day] || 0) + session.durationMs
+  })
+
+  const data = Object.keys(durations)
+    .sort()
+    .map((day) => ({ day, value: msToHDecimal(durations[day]) }))
+
+  return {
+    from: isoDate(windowStart),
+    to: isoDate(tomorrow),
+    data,
+    past_year_hours: msToHDecimal(totalDurationMs(inWindow)),
   }
 }
 
@@ -333,11 +372,16 @@ export function calcHistoryData(
 }
 
 export function calcDurationPieData(sessions: DemoSession[]) {
-  return DURATION_KEYS.map((duration: DurationKey) => ({
-    duration,
-    amount: sessions.filter((session) => session.durationKey === duration)
-      .length,
-  }))
+  return DURATION_KEYS.map((duration: DurationKey) => {
+    const bucket = sessions.filter(
+      (session) => session.durationKey === duration
+    )
+    return {
+      duration,
+      amount: bucket.length,
+      hours: msToHDecimal(totalDurationMs(bucket)),
+    }
+  })
 }
 
 export function formatSeconds(value: number): string {
@@ -438,6 +482,6 @@ export function calcDailyRecord(sessions: DemoSession[]) {
 
   return {
     date: strftime(dateOfDay(best, sessions[0].start), "%b %-d, %Y"),
-    duration: msToH(perDay[best]),
+    duration: msToHDecimal(perDay[best]),
   }
 }

--- a/lib/demo/time.ts
+++ b/lib/demo/time.ts
@@ -71,10 +71,6 @@ export function msToM(ms: number): number {
   return pyRound(ms / 60000)
 }
 
-export function msToH(ms: number): number {
-  return pyRound(ms / 3600000)
-}
-
 /** Hours to one decimal, for periods short enough that whole hours would round
  * away most of the progress. */
 export function msToHDecimal(ms: number): number {

--- a/lib/demo/views.ts
+++ b/lib/demo/views.ts
@@ -15,6 +15,7 @@ import {
   calcDurationPieData,
   calcHeatmapData,
   calcHistoryData,
+  calcTimeHeatmapData,
   calcMaxDailyStreak,
   calcPunctualityPieData,
   calcRepeatPartners,
@@ -37,7 +38,6 @@ import {
   getCurrMonthStart,
   getCurrWeekStart,
   getCurrYearStart,
-  msToH,
   msToHDecimal,
   msToM,
   pyRound1,
@@ -68,6 +68,7 @@ export function buildStreak(now: Date, weekStart: WeekStartDay) {
     monthly_streak: calcCurrStreak(sessions, "M", now),
     max_daily_streak: calcMaxDailyStreak(sessions),
     heatmap_data: calcHeatmapData(sessions, now, weekStart),
+    time_heatmap_data: calcTimeHeatmapData(sessions, now, weekStart),
     history_data: calcHistoryData(allSessions, now, 3),
     daily: {
       subheading: formatDateLabel(currDayStart, DATE_LABEL),
@@ -158,16 +159,16 @@ export function buildMonth(now: Date) {
   const l6mSessions = between(sessions, l6mStart, currMonthStart)
 
   const dateFormat = "%B %Y"
-  const currMonthMs = totalDurationMs(currMonthSessions)
-  const prevMonthMs = totalDurationMs(prevMonthSessions)
+  const currMonthHours = msToHDecimal(totalDurationMs(currMonthSessions))
+  const prevMonthHours = msToHDecimal(totalDurationMs(prevMonthSessions))
 
   return {
     curr_period: {
       subheading: formatDateLabel(currMonthStart, dateFormat),
       sessions_total: currMonthSessions.length,
       sessions_delta: currMonthSessions.length - prevMonthSessions.length,
-      hours_total: msToH(currMonthMs),
-      hours_delta: msToH(currMonthMs - prevMonthMs),
+      hours_total: currMonthHours,
+      hours_delta: pyRound1(currMonthHours - prevMonthHours),
       partners_total: countPartners(currMonthSessions),
       partners_repeat: calcRepeatPartners(currMonthSessions),
       period_type: "month",
@@ -210,16 +211,16 @@ export function buildYear(now: Date) {
   const prevYearSessions = between(sessions, prevYearStart, currYearStart)
 
   const dateFormat = "%Y"
-  const currYearMs = totalDurationMs(currYearSessions)
-  const prevYearMs = totalDurationMs(prevYearSessions)
+  const currYearHours = msToHDecimal(totalDurationMs(currYearSessions))
+  const prevYearHours = msToHDecimal(totalDurationMs(prevYearSessions))
 
   return {
     curr_period: {
       subheading: formatDateLabel(currYearStart, dateFormat),
       sessions_total: currYearSessions.length,
       sessions_delta: currYearSessions.length - prevYearSessions.length,
-      hours_total: msToH(currYearMs),
-      hours_delta: msToH(currYearMs - prevYearMs),
+      hours_total: currYearHours,
+      hours_delta: pyRound1(currYearHours - prevYearHours),
       partners_total: countPartners(currYearSessions),
       partners_repeat: calcRepeatPartners(currYearSessions),
       period_type: "year",
@@ -227,7 +228,7 @@ export function buildYear(now: Date) {
     prev_period: {
       subheading: formatDateLabel(prevYearStart, dateFormat),
       sessions_total: prevYearSessions.length,
-      hours_total: msToH(prevYearMs),
+      hours_total: prevYearHours,
       partners_total: countPartners(prevYearSessions),
       partners_repeat: calcRepeatPartners(prevYearSessions),
     },
@@ -266,7 +267,7 @@ export function buildLifetime(now: Date) {
     curr_period: {
       subheading: `${firstSessionDate} - Present`,
       sessions_total: DEMO_PROFILE.total_session_count,
-      hours_total: msToH(totalDurationMs(sessions)),
+      hours_total: msToHDecimal(totalDurationMs(sessions)),
       partners_total: countPartners(sessions),
       partners_repeat: calcRepeatPartners(sessions),
       first_session_date: firstSessionDate,


### PR DESCRIPTION
## Summary

Closes #33.

- Total hours on the month, year, and lifetime tabs rounded to the nearest whole hour (e.g. 4h10m showed as "4"). Week and the streak tab already reported decimal hours via `ms_to_h_decimal`; this extends that same precision everywhere and removes the now-unused whole-hour `ms_to_h` helper.
- "Sessions by duration" now reports total time per bucket (e.g. `4 (33%) · 1.7h`), not just session count.
- Added a time heatmap next to the existing sessions heatmap on the streak tab, colored by daily hours instead of session count.
- Updated the demo dashboard's TypeScript mirror (`lib/demo`) to match, verified against the real API's output with the same golden-payload comparison `scripts/check-demo-fixture.ts` runs.

## Test plan

- [x] `npm run build` and `npm run lint` pass
- [x] `npx tsc --noEmit` passes (no new type errors)
- [x] `npm run check:demo` passes (72/72 payloads match between the Python API and the TypeScript demo mirror)
- [x] Verified `calc_duration_pie_data`, `calc_daily_record`, `calc_heatmap_data`, and `calc_time_heatmap_data` directly against sample sessions
- [x] Loaded `/dashboard/streak`, `/week`, `/month`, `/year`, `/lifetime` with `?demo=true` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)